### PR TITLE
Hydra dev

### DIFF
--- a/source/Configs.cs
+++ b/source/Configs.cs
@@ -99,6 +99,7 @@ namespace cba
         public bool runFullHydra { get; private set; }
         public int maxSplitPerIteration { get; private set; }
         public int alpha { get; private set; }
+        public string fileName { get; private set; }
 
         public string boogieOpts;
         public bool cadeTiming { get; private set; }
@@ -208,12 +209,12 @@ namespace cba
 
             Configs config = new Configs();
             config.inputFile = inputFile;
-
+            cba.Util.HydraConfig.fileName = inputFile;
             foreach (var flag in flags)
             {
                 config.parseFlag(flag);
             }
-
+            
             // Concatenate include files
             if (config.includeFiles.Count != 0)
             {
@@ -299,6 +300,7 @@ namespace cba
             runFullHydra = false;
             maxSplitPerIteration = 1;
             alpha = 100;
+            fileName = "wrong";
             refinementAlgo = "tttt";
             noCallTreeReuse = false;
             cadeTiming = false;

--- a/source/Configs.cs
+++ b/source/Configs.cs
@@ -98,6 +98,7 @@ namespace cba
 
         public bool runFullHydra { get; private set; }
         public int maxSplitPerIteration { get; private set; }
+        public int alpha { get; private set; }
 
         public string boogieOpts;
         public bool cadeTiming { get; private set; }
@@ -297,6 +298,7 @@ namespace cba
             printFinalProgOnly = false;
             runFullHydra = false;
             maxSplitPerIteration = 1;
+            alpha = 100;
             refinementAlgo = "tttt";
             noCallTreeReuse = false;
             cadeTiming = false;
@@ -569,6 +571,12 @@ namespace cba
                 var split = flag.Split(sep);
                 maxSplitPerIteration = Int32.Parse(split[1]);
                 cba.Util.HydraConfig.maxSplitPerIteration = maxSplitPerIteration;
+            }
+            else if (flag.StartsWith("/alpha"))
+            {
+                var split = flag.Split(sep);
+                alpha = Int32.Parse(split[1]);
+                cba.Util.HydraConfig.alpha = alpha;
             }
             else if (flag.StartsWith("/hydraServerURI:"))
             {

--- a/source/CoreLib/BoogieVerify.cs
+++ b/source/CoreLib/BoogieVerify.cs
@@ -17,7 +17,7 @@ namespace cba.Util
         public static string hydraServerURI = null;
         public static bool startHydra = false;
         public static int maxSplitPerIteration = 1;
-        public static int alpha = 100;
+        public static int alpha = 0;
     }
 
     public static class BoogieVerify

--- a/source/CoreLib/BoogieVerify.cs
+++ b/source/CoreLib/BoogieVerify.cs
@@ -17,6 +17,7 @@ namespace cba.Util
         public static string hydraServerURI = null;
         public static bool startHydra = false;
         public static int maxSplitPerIteration = 1;
+        public static int alpha = 100;
     }
 
     public static class BoogieVerify

--- a/source/CoreLib/BoogieVerify.cs
+++ b/source/CoreLib/BoogieVerify.cs
@@ -18,6 +18,7 @@ namespace cba.Util
         public static bool startHydra = false;
         public static int maxSplitPerIteration = 1;
         public static int alpha = 0;
+        public static string fileName = "wrong";
     }
 
     public static class BoogieVerify

--- a/source/CoreLib/StratifiedInlining.cs
+++ b/source/CoreLib/StratifiedInlining.cs
@@ -1899,32 +1899,33 @@ namespace CoreLib
                     if (outcome == Outcome.Errors)
                     {
                         foreach (var scs in reporter.callSitesToExpand)
-		                {                         
-		                    calltreeToSend = calltreeToSend + GetPersistentID(scs) + ",";
+                        {
+                            calltreeToSend = calltreeToSend + GetPersistentID(scs) + ",";
 
-		                    openCallSites.Remove(scs);
-		                    StratifiedVC svc = null;
-		                    if (cba.Util.BoogieVerify.options.newStratifiedInliningAlgo.ToLower() == "ucsplitparallel2")    //Do not assert labels for inlined callsites. Unsat core should contain only open callsites
-		                        svc = Expand(scs);
-		                    else
-		                        svc = Expand(scs, "label_" + scs.callSiteExpr.ToString(), true, true);
-		                    if (svc != null)
-		                    {
-		                        openCallSites.UnionWith(svc.CallSites);
-		                        Debug.Assert(!cba.Util.BoogieVerify.options.useFwdBck);
-		                    }
-		                }
-		                if (ucore != null || ucore.Count != 0)
-		                {
+                            openCallSites.Remove(scs);
+                            StratifiedVC svc = null;
+                            if (cba.Util.BoogieVerify.options.newStratifiedInliningAlgo.ToLower() == "ucsplitparallel2")    //Do not assert labels for inlined callsites. Unsat core should contain only open callsites
+                                svc = Expand(scs);
+                            else
+                                svc = Expand(scs, "label_" + scs.callSiteExpr.ToString(), true, true);
+                            if (svc != null)
+                            {
+                                openCallSites.UnionWith(svc.CallSites);
+                                Debug.Assert(!cba.Util.BoogieVerify.options.useFwdBck);
+                            }
+                        }
+                        if (ucore != null || ucore.Count != 0)
+                        {
 
-		                    foreach (StratifiedCallSite cs in attachedVC.Keys)
-		                    {
-		                        if (ucore.Contains("label_" + cs.callSiteExpr.ToString()))
-		                        {
-		                            CallSitesInUCore.Add(cs);
-		                        }
-		                    }
-		                }
+                            foreach (StratifiedCallSite cs in attachedVC.Keys)
+                            {
+                                if (ucore.Contains("label_" + cs.callSiteExpr.ToString()))
+                                {
+                                    CallSitesInUCore.Add(cs);
+                                }
+                            }
+                        }
+                    }
                 }
                 else // verificationAlgorithm == "ucsplitparallel5"
                 {

--- a/source/CoreLib/StratifiedInlining.cs
+++ b/source/CoreLib/StratifiedInlining.cs
@@ -1276,6 +1276,8 @@ namespace CoreLib
             bool splitOnDemand = false;
             bool learnProofs = false;
             int maxSplitPerIteration = cba.Util.HydraConfig.maxSplitPerIteration;
+            int alpha = cba.Util.HydraConfig.alpha;
+            int beta = 100 - alpha;
             int numSplitThisIteration = 0;
             int aggressiveSplitQueryBound = 5;
             string verificationAlgorithm = cba.Util.BoogieVerify.options.newStratifiedInliningAlgo.ToLower();
@@ -1871,6 +1873,20 @@ namespace CoreLib
                 if (writeLog)
                     Console.WriteLine(clientID + " = point 4");
                 bool newCallSiteFound = false;
+                Random r = new Random();
+                int randomNumber = r.Next(100);
+                //itachi
+                if(randomNumber < alpha && verificationAlgorithm == "ucsplitparallel")
+                {
+                    verificationAlgorithm = "ucsplitparallel5";
+                    //Console.WriteLine(clientID + " => changing to UW");
+                }
+                else if(randomNumber >= alpha && verificationAlgorithm == "ucsplitparallel5")
+                {
+                    verificationAlgorithm = "ucsplitparallel";
+                    //Console.WriteLine( clientID + " => changing to OR");
+                }
+
                 if (verificationAlgorithm != "ucsplitparallel5")
                 {
                     reporter.callSitesToExpand = new List<StratifiedCallSite>();
@@ -3167,6 +3183,7 @@ namespace CoreLib
                 }
                 else
                 {
+                    //Console.WriteLine(clientID + " => new Partition");
                     if (writeLog)
                         Console.WriteLine("Request Calltree here from client {0}", clientID);
                     replyFromServer = null;

--- a/source/CoreLib/StratifiedInlining.cs
+++ b/source/CoreLib/StratifiedInlining.cs
@@ -1990,6 +1990,10 @@ namespace CoreLib
                             numOfInlinedCallsites.Add(reporter.callSitesToExpand.Count());
                             var splits = reporter.callSitesToExpand.Count().ToString() + "\n";
                             File.AppendAllText(toFile, splits);
+                            if(reporter.callSitesToExpand.Count == 0)
+                            {
+                                break;
+                            }
                             foreach (var scs in reporter.callSitesToExpand)
                             {
                                 calltreeToSend = calltreeToSend + GetPersistentID(scs) + ",";
@@ -2010,7 +2014,7 @@ namespace CoreLib
                 }
 
                 //Add all open callsites in unsat core to list
-                if(ucore != null && verificationAlgorithm == "ucsplitparallel5" || verificationAlgorithm == "ucsplitparallel6" || verificationAlgorithm == "ucsplitparallel7")
+                if(ucore != null && (verificationAlgorithm == "ucsplitparallel5" || verificationAlgorithm == "ucsplitparallel6" || verificationAlgorithm == "ucsplitparallel7"))
                 {
                     foreach (var scs in openCallSites)
                     {


### PR DESCRIPTION
### Overview

1. Add code for `α*UW + β*OR`
2. Add code for UW union/intersection OR 
3. Add code for measuring 2 things 
    1. Z3 query times
    2. Number of in-lined call-sites per iteration
### Use
- Added extra flag _/alpha_ in hydra arguments, values ranging from 0 to 100. _α = 0_ means OR and _α = 100_ means UW. (β = 100 - α)
- For Inlining callsites in Union use flag value _ucsplitparallel6_
- For Inlining callsites in Intersection use flag value _ucsplitparallel7_
- Files with suffix __clientID_stats.txt_ will be genearted in the output folder.
   - First line has under approximation z3 query times
   - Second line has over approximation z3 query times
   - Third line has all z3 query times
   - Forth line has number of splits per iteration
- For memory consumption need to run another script externally

### Code Logic changes

- Updated Program.cs (server) to save the stats and then only exit the current verification file task.
- Checked every response from server if it is _SendResetTime_ then return the stats. ( _SendResetTime_ : This will be the case when we have founded a definitive verdict for file)

### TODO

- Stats are saved only for OK and TIMEDOUT cases, handle the same for NOK.
- Clean the code